### PR TITLE
Including reference to Hanami

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ So let's go!
 
 [abidria-api](https://github.com/jordifierro/abidria-api) - Django application written with clean architecture. There also an [article](https://engineering.21buttons.com/clean-architecture-in-django-d326a4ab86a9) by Jordi Fierro which explains architecture components and how they interact with each other.
 
+[Hanami-rb](http://hanamirb.org/guides/1.1/getting-started/) - A good option out of the Rails world, Hanami is an emerging framework that encourages and helps to design DDD applications in Ruby. The getting started by itself explains some DDD concepts and how they fits inside the framework.
+
 ## Training
 
 [DDD Patterns in Python](http://sixty-north.com/domain_driven_design_in_python.html) - Sixty North offers two-day classroom training on implementing DDD in Python with relational or event-sourced persistence. (Paid)


### PR DESCRIPTION
Hi Valentin, I'm including a reference to Hanami framework. We use this at [Creditas](https://www.creditas.com.br/) in our core application. 

Not sure if I included it in the right section. Please let me know if you want me to change the location.

Also... we have some posts on our blog ([here](https://diariodebordo.creditas.com.br/hanami-em-production-2-anos-depois-parte-1/) and [here](https://diariodebordo.creditas.com.br/hanami-em-production-2-anos-depois-parte-2/)) talking about our experience with Hanami (since the beta) and DDD but they are written in portuguese. Do you think make sense to put it somewhere here? Maybe a version of the readme in portuguese, IDK..